### PR TITLE
feat: add ESLint plugin with no-unused-viewmodel-properties rule

### DIFF
--- a/__tests__/eslint/fixtures/unused-property/pet-store.vue
+++ b/__tests__/eslint/fixtures/unused-property/pet-store.vue
@@ -1,0 +1,13 @@
+<template>
+  <div>
+    <h2>{{ viewModel.headline }}</h2>
+    <ol>
+      <li v-for="pet in viewModel.pets" :key="pet">{{ pet }}</li>
+    </ol>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { usePetStorePresenter } from './use-pet-store.presenter'
+const { viewModel } = usePetStorePresenter()
+</script>

--- a/__tests__/eslint/fixtures/unused-property/use-pet-store.presenter.ts
+++ b/__tests__/eslint/fixtures/unused-property/use-pet-store.presenter.ts
@@ -1,0 +1,17 @@
+import { presenterFactory } from '../../../../lib/main'
+import { computed, reactive } from 'vue'
+
+export const usePetStorePresenter = presenterFactory(() => {
+  const state = reactive({
+    isLoading: true,
+    pets: [] as string[],
+  })
+
+  return {
+    viewModel: computed(() => ({
+      headline: state.isLoading ? 'Loading...' : 'Welcome',
+      pets: state.pets,
+      showSkeletonLoader: state.isLoading,
+    })),
+  }
+})

--- a/__tests__/eslint/fixtures/used-all-properties/pet-store.vue
+++ b/__tests__/eslint/fixtures/used-all-properties/pet-store.vue
@@ -1,0 +1,14 @@
+<template>
+  <div>
+    <h2>{{ viewModel.headline }}</h2>
+    <p v-if="viewModel.showSkeletonLoader">Loading...</p>
+    <ol>
+      <li v-for="pet in viewModel.pets" :key="pet">{{ pet }}</li>
+    </ol>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { usePetStorePresenter } from './use-pet-store.presenter'
+const { viewModel } = usePetStorePresenter()
+</script>

--- a/__tests__/eslint/fixtures/used-all-properties/use-pet-store.presenter.ts
+++ b/__tests__/eslint/fixtures/used-all-properties/use-pet-store.presenter.ts
@@ -1,0 +1,17 @@
+import { presenterFactory } from '../../../../lib/main'
+import { computed, reactive } from 'vue'
+
+export const usePetStorePresenter = presenterFactory(() => {
+  const state = reactive({
+    isLoading: true,
+    pets: [] as string[],
+  })
+
+  return {
+    viewModel: computed(() => ({
+      headline: state.isLoading ? 'Loading...' : 'Welcome',
+      pets: state.pets,
+      showSkeletonLoader: state.isLoading,
+    })),
+  }
+})

--- a/__tests__/eslint/fixtures/used-in-script-setup/counter.vue
+++ b/__tests__/eslint/fixtures/used-in-script-setup/counter.vue
@@ -1,0 +1,10 @@
+<template>
+  <div>{{ viewModel.count }}</div>
+</template>
+
+<script setup lang="ts">
+import { useCounterPresenter } from './use-counter.presenter'
+import { watch } from 'vue'
+const { viewModel } = useCounterPresenter()
+watch(() => viewModel.isEven, (val) => console.log(val))
+</script>

--- a/__tests__/eslint/fixtures/used-in-script-setup/counter.vue
+++ b/__tests__/eslint/fixtures/used-in-script-setup/counter.vue
@@ -6,5 +6,5 @@
 import { useCounterPresenter } from './use-counter.presenter'
 import { watch } from 'vue'
 const { viewModel } = useCounterPresenter()
-watch(() => viewModel.isEven, (val) => console.log(val))
+watch(() => viewModel.value.isEven, (val) => console.log(val))
 </script>

--- a/__tests__/eslint/fixtures/used-in-script-setup/use-counter.presenter.ts
+++ b/__tests__/eslint/fixtures/used-in-script-setup/use-counter.presenter.ts
@@ -1,0 +1,13 @@
+import { presenterFactory } from '../../../../lib/main'
+import { computed, ref } from 'vue'
+
+export const useCounterPresenter = presenterFactory(() => {
+  const count = ref(0)
+
+  return {
+    viewModel: computed(() => ({
+      count: count.value,
+      isEven: count.value % 2 === 0,
+    })),
+  }
+})

--- a/__tests__/eslint/fixtures/viewmodel-alias/counter.vue
+++ b/__tests__/eslint/fixtures/viewmodel-alias/counter.vue
@@ -6,5 +6,5 @@
 import { useCounterPresenter } from './use-counter.presenter'
 import { watch } from 'vue'
 const { viewModel: counterVM } = useCounterPresenter()
-watch(() => counterVM.isEven, (val) => console.log(val))
+watch(() => counterVM.value.isEven, (val) => console.log(val))
 </script>

--- a/__tests__/eslint/fixtures/viewmodel-alias/counter.vue
+++ b/__tests__/eslint/fixtures/viewmodel-alias/counter.vue
@@ -1,0 +1,10 @@
+<template>
+  <div>{{ counterVM.count }}</div>
+</template>
+
+<script setup lang="ts">
+import { useCounterPresenter } from './use-counter.presenter'
+import { watch } from 'vue'
+const { viewModel: counterVM } = useCounterPresenter()
+watch(() => counterVM.isEven, (val) => console.log(val))
+</script>

--- a/__tests__/eslint/fixtures/viewmodel-alias/use-counter.presenter.ts
+++ b/__tests__/eslint/fixtures/viewmodel-alias/use-counter.presenter.ts
@@ -1,0 +1,13 @@
+import { presenterFactory } from '../../../../lib/main'
+import { computed, ref } from 'vue'
+
+export const useCounterPresenter = presenterFactory(() => {
+  const count = ref(0)
+
+  return {
+    viewModel: computed(() => ({
+      count: count.value,
+      isEven: count.value % 2 === 0,
+    })),
+  }
+})

--- a/__tests__/eslint/no-unused-viewmodel-properties.test.ts
+++ b/__tests__/eslint/no-unused-viewmodel-properties.test.ts
@@ -1,0 +1,57 @@
+import { RuleTester } from 'eslint'
+import typescriptParser from '@typescript-eslint/parser'
+import { describe, it } from 'vitest'
+import path from 'node:path'
+import fs from 'node:fs'
+import rule from '../../lib/eslint/rules/no-unused-viewmodel-properties'
+
+RuleTester.describe = describe
+RuleTester.it = it
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parser: typescriptParser,
+    ecmaVersion: 2022,
+    sourceType: 'module',
+  },
+})
+
+const fixturesDir = path.resolve(__dirname, 'fixtures')
+
+function readFixture(scenario: string, fileName: string): string {
+  return fs.readFileSync(path.resolve(fixturesDir, scenario, fileName), 'utf8')
+}
+
+function fixturePath(scenario: string, fileName: string): string {
+  return path.resolve(fixturesDir, scenario, fileName)
+}
+
+ruleTester.run('no-unused-viewmodel-properties', rule, {
+  valid: [
+    {
+      name: 'all viewModel properties are used in template',
+      code: readFixture('used-all-properties', 'use-pet-store.presenter.ts'),
+      filename: fixturePath('used-all-properties', 'use-pet-store.presenter.ts'),
+    },
+    {
+      name: 'viewModel property used only in <script setup>',
+      code: readFixture('used-in-script-setup', 'use-counter.presenter.ts'),
+      filename: fixturePath('used-in-script-setup', 'use-counter.presenter.ts'),
+    },
+    {
+      name: 'viewModel aliased at destructuring — all properties used',
+      code: readFixture('viewmodel-alias', 'use-counter.presenter.ts'),
+      filename: fixturePath('viewmodel-alias', 'use-counter.presenter.ts'),
+    },
+  ],
+  invalid: [
+    {
+      name: 'viewModel property not used in any importing .vue file',
+      code: readFixture('unused-property', 'use-pet-store.presenter.ts'),
+      filename: fixturePath('unused-property', 'use-pet-store.presenter.ts'),
+      errors: [
+        { messageId: 'unusedProperty', data: { property: 'showSkeletonLoader' } },
+      ],
+    },
+  ],
+})

--- a/docs/superpowers/plans/2026-03-10-eslint-plugin.md
+++ b/docs/superpowers/plans/2026-03-10-eslint-plugin.md
@@ -1,0 +1,797 @@
+# ESLint Plugin Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a `no-unused-viewmodel-properties` ESLint rule as part of this library that reports viewModel properties in presenter files that are never accessed in any importing `.vue` file.
+
+**Architecture:** A single ESLint rule runs on `.ts` presenter files, extracts viewModel property names from the AST, then reads importing `.vue` files from disk to check template and script setup sections for `viewModel.propertyName` access patterns (including aliased viewModel names). The rule and plugin entry point are compiled to `dist/eslint.js` via a second Vite build entry.
+
+**Tech Stack:** ESLint 9, `@typescript-eslint/parser` (dev/test only), Vite multi-entry build, Vitest + `RuleTester`
+
+---
+
+## File Map
+
+| Path | Action | Responsibility |
+|------|--------|----------------|
+| `lib/eslint/index.ts` | Create | Plugin entry — exports the plugin object with the rule |
+| `lib/eslint/rules/no-unused-viewmodel-properties.ts` | Create | The rule — detection, file scanning, reporting |
+| `__tests__/eslint/no-unused-viewmodel-properties.test.ts` | Create | RuleTester tests for all scenarios |
+| `__tests__/eslint/fixtures/used-all-properties/use-pet-store.presenter.ts` | Create | Fixture: presenter with 3 viewModel props |
+| `__tests__/eslint/fixtures/used-all-properties/pet-store.vue` | Create | Fixture: template using all 3 props |
+| `__tests__/eslint/fixtures/unused-property/use-pet-store.presenter.ts` | Create | Fixture: presenter with 3 viewModel props |
+| `__tests__/eslint/fixtures/unused-property/pet-store.vue` | Create | Fixture: template using only 2 props |
+| `__tests__/eslint/fixtures/used-in-script-setup/use-counter.presenter.ts` | Create | Fixture: presenter with 2 viewModel props |
+| `__tests__/eslint/fixtures/used-in-script-setup/counter.vue` | Create | Fixture: one prop in template, one only in script setup |
+| `__tests__/eslint/fixtures/viewmodel-alias/use-counter.presenter.ts` | Create | Fixture: presenter with 2 viewModel props |
+| `__tests__/eslint/fixtures/viewmodel-alias/counter.vue` | Create | Fixture: viewModel destructured with alias |
+| `vite.config.ts` | Modify | Add `eslint` as second build entry point |
+| `package.json` | Modify | Add `eslint` to `peerDependencies`, `devDependencies`, and `exports` |
+
+---
+
+## Chunk 1: Dependencies and Skeletons
+
+### Task 1: Install ESLint and TypeScript parser
+
+**Files:**
+- Modify: `package.json`
+
+- [ ] **Step 1: Install devDependencies**
+
+```bash
+npm install --save-dev eslint @typescript-eslint/parser
+```
+
+Expected: `package.json` devDependencies updated with `eslint` and `@typescript-eslint/parser`.
+
+- [ ] **Step 2: Add eslint as optional peerDependency**
+
+In `package.json`, add to `"peerDependencies"`:
+```json
+"eslint": ">=8.0.0"
+```
+
+And add `"peerDependenciesMeta"` section:
+```json
+"peerDependenciesMeta": {
+  "eslint": {
+    "optional": true
+  }
+}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add package.json package-lock.json
+git commit -m "chore: add eslint and typescript-parser dev dependencies"
+```
+
+---
+
+### Task 2: Create library file skeletons
+
+**Files:**
+- Create: `lib/eslint/index.ts`
+- Create: `lib/eslint/rules/no-unused-viewmodel-properties.ts`
+
+- [ ] **Step 1: Create the rule skeleton**
+
+Create `lib/eslint/rules/no-unused-viewmodel-properties.ts`:
+
+```typescript
+import type { Rule } from 'eslint'
+
+const rule: Rule.RuleModule = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description: 'Disallow unused viewModel properties in presenter files',
+    },
+    messages: {
+      unusedProperty: 'viewModel property "{{property}}" is not used in any importing .vue file',
+    },
+    schema: [],
+  },
+  create(context) {
+    return {}
+  },
+}
+
+export default rule
+```
+
+- [ ] **Step 2: Create the plugin entry**
+
+Create `lib/eslint/index.ts`:
+
+```typescript
+import noUnusedViewModelProperties from './rules/no-unused-viewmodel-properties'
+
+const plugin = {
+  rules: {
+    'no-unused-viewmodel-properties': noUnusedViewModelProperties,
+  },
+}
+
+export default plugin
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add lib/eslint/
+git commit -m "chore: add eslint plugin and rule skeletons"
+```
+
+---
+
+## Chunk 2: Fixture Files
+
+### Task 3: Create "used-all-properties" fixtures
+
+**Files:**
+- Create: `__tests__/eslint/fixtures/used-all-properties/use-pet-store.presenter.ts`
+- Create: `__tests__/eslint/fixtures/used-all-properties/pet-store.vue`
+
+- [ ] **Step 1: Create the presenter fixture**
+
+Create `__tests__/eslint/fixtures/used-all-properties/use-pet-store.presenter.ts`:
+
+```typescript
+import { presenterFactory } from '../../../../lib/main'
+import { computed, reactive } from 'vue'
+
+export const usePetStorePresenter = presenterFactory(() => {
+  const state = reactive({
+    isLoading: true,
+    pets: [] as string[],
+  })
+
+  return {
+    viewModel: computed(() => ({
+      headline: state.isLoading ? 'Loading...' : 'Welcome',
+      pets: state.pets,
+      showSkeletonLoader: state.isLoading,
+    })),
+  }
+})
+```
+
+- [ ] **Step 2: Create the Vue component fixture**
+
+Create `__tests__/eslint/fixtures/used-all-properties/pet-store.vue`:
+
+```vue
+<template>
+  <div>
+    <h2>{{ viewModel.headline }}</h2>
+    <p v-if="viewModel.showSkeletonLoader">Loading...</p>
+    <ol>
+      <li v-for="pet in viewModel.pets" :key="pet">{{ pet }}</li>
+    </ol>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { usePetStorePresenter } from './use-pet-store.presenter'
+const { viewModel } = usePetStorePresenter()
+</script>
+```
+
+---
+
+### Task 4: Create "unused-property" fixtures
+
+**Files:**
+- Create: `__tests__/eslint/fixtures/unused-property/use-pet-store.presenter.ts`
+- Create: `__tests__/eslint/fixtures/unused-property/pet-store.vue`
+
+- [ ] **Step 1: Create the presenter fixture**
+
+Create `__tests__/eslint/fixtures/unused-property/use-pet-store.presenter.ts`:
+
+```typescript
+import { presenterFactory } from '../../../../lib/main'
+import { computed, reactive } from 'vue'
+
+export const usePetStorePresenter = presenterFactory(() => {
+  const state = reactive({
+    isLoading: true,
+    pets: [] as string[],
+  })
+
+  return {
+    viewModel: computed(() => ({
+      headline: state.isLoading ? 'Loading...' : 'Welcome',
+      pets: state.pets,
+      showSkeletonLoader: state.isLoading,
+    })),
+  }
+})
+```
+
+- [ ] **Step 2: Create the Vue component fixture — note: `showSkeletonLoader` intentionally omitted**
+
+Create `__tests__/eslint/fixtures/unused-property/pet-store.vue`:
+
+```vue
+<template>
+  <div>
+    <h2>{{ viewModel.headline }}</h2>
+    <ol>
+      <li v-for="pet in viewModel.pets" :key="pet">{{ pet }}</li>
+    </ol>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { usePetStorePresenter } from './use-pet-store.presenter'
+const { viewModel } = usePetStorePresenter()
+</script>
+```
+
+---
+
+### Task 5: Create "used-in-script-setup" fixtures
+
+**Files:**
+- Create: `__tests__/eslint/fixtures/used-in-script-setup/use-counter.presenter.ts`
+- Create: `__tests__/eslint/fixtures/used-in-script-setup/counter.vue`
+
+- [ ] **Step 1: Create the presenter fixture**
+
+Create `__tests__/eslint/fixtures/used-in-script-setup/use-counter.presenter.ts`:
+
+```typescript
+import { presenterFactory } from '../../../../lib/main'
+import { computed, ref } from 'vue'
+
+export const useCounterPresenter = presenterFactory(() => {
+  const count = ref(0)
+
+  return {
+    viewModel: computed(() => ({
+      count: count.value,
+      isEven: count.value % 2 === 0,
+    })),
+  }
+})
+```
+
+- [ ] **Step 2: Create the Vue component fixture — `isEven` is used only in script setup**
+
+Create `__tests__/eslint/fixtures/used-in-script-setup/counter.vue`:
+
+```vue
+<template>
+  <div>{{ viewModel.count }}</div>
+</template>
+
+<script setup lang="ts">
+import { useCounterPresenter } from './use-counter.presenter'
+import { watch } from 'vue'
+const { viewModel } = useCounterPresenter()
+watch(() => viewModel.isEven, (val) => console.log(val))
+</script>
+```
+
+---
+
+### Task 6: Create "viewmodel-alias" fixtures
+
+**Files:**
+- Create: `__tests__/eslint/fixtures/viewmodel-alias/use-counter.presenter.ts`
+- Create: `__tests__/eslint/fixtures/viewmodel-alias/counter.vue`
+
+- [ ] **Step 1: Create the presenter fixture**
+
+Create `__tests__/eslint/fixtures/viewmodel-alias/use-counter.presenter.ts`:
+
+```typescript
+import { presenterFactory } from '../../../../lib/main'
+import { computed, ref } from 'vue'
+
+export const useCounterPresenter = presenterFactory(() => {
+  const count = ref(0)
+
+  return {
+    viewModel: computed(() => ({
+      count: count.value,
+      isEven: count.value % 2 === 0,
+    })),
+  }
+})
+```
+
+- [ ] **Step 2: Create the Vue component fixture — viewModel is aliased as `counterVM`**
+
+Create `__tests__/eslint/fixtures/viewmodel-alias/counter.vue`:
+
+```vue
+<template>
+  <div>{{ counterVM.count }}</div>
+</template>
+
+<script setup lang="ts">
+import { useCounterPresenter } from './use-counter.presenter'
+import { watch } from 'vue'
+const { viewModel: counterVM } = useCounterPresenter()
+watch(() => counterVM.isEven, (val) => console.log(val))
+</script>
+```
+
+- [ ] **Step 3: Commit all fixtures**
+
+```bash
+git add __tests__/eslint/
+git commit -m "test: add eslint rule fixture files"
+```
+
+---
+
+## Chunk 3: Tests (TDD — Write First)
+
+### Task 7: Write the test file
+
+**Files:**
+- Create: `__tests__/eslint/no-unused-viewmodel-properties.test.ts`
+
+- [ ] **Step 1: Create the test file**
+
+Create `__tests__/eslint/no-unused-viewmodel-properties.test.ts`:
+
+```typescript
+import { RuleTester } from 'eslint'
+import typescriptParser from '@typescript-eslint/parser'
+import { describe, it } from 'vitest'
+import path from 'node:path'
+import fs from 'node:fs'
+import rule from '../../lib/eslint/rules/no-unused-viewmodel-properties'
+
+RuleTester.describe = describe
+RuleTester.it = it
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parser: typescriptParser,
+    ecmaVersion: 2022,
+    sourceType: 'module',
+  },
+})
+
+const fixturesDir = path.resolve(__dirname, 'fixtures')
+
+function readFixture(scenario: string, fileName: string): string {
+  return fs.readFileSync(path.resolve(fixturesDir, scenario, fileName), 'utf8')
+}
+
+function fixturePath(scenario: string, fileName: string): string {
+  return path.resolve(fixturesDir, scenario, fileName)
+}
+
+ruleTester.run('no-unused-viewmodel-properties', rule, {
+  valid: [
+    {
+      name: 'all viewModel properties are used in template',
+      code: readFixture('used-all-properties', 'use-pet-store.presenter.ts'),
+      filename: fixturePath('used-all-properties', 'use-pet-store.presenter.ts'),
+    },
+    {
+      name: 'viewModel property used only in <script setup>',
+      code: readFixture('used-in-script-setup', 'use-counter.presenter.ts'),
+      filename: fixturePath('used-in-script-setup', 'use-counter.presenter.ts'),
+    },
+    {
+      name: 'viewModel aliased at destructuring — all properties used',
+      code: readFixture('viewmodel-alias', 'use-counter.presenter.ts'),
+      filename: fixturePath('viewmodel-alias', 'use-counter.presenter.ts'),
+    },
+  ],
+  invalid: [
+    {
+      name: 'viewModel property not used in any importing .vue file',
+      code: readFixture('unused-property', 'use-pet-store.presenter.ts'),
+      filename: fixturePath('unused-property', 'use-pet-store.presenter.ts'),
+      errors: [
+        { messageId: 'unusedProperty', data: { property: 'showSkeletonLoader' } },
+      ],
+    },
+  ],
+})
+```
+
+- [ ] **Step 2: Run tests — confirm the invalid case fails**
+
+```bash
+npm test -- __tests__/eslint/no-unused-viewmodel-properties.test.ts
+```
+
+Expected: The 1 invalid case fails (rule reports no errors yet, but RuleTester expects 1 error). The 3 valid cases pass vacuously since the empty rule also reports no errors.
+
+- [ ] **Step 3: Commit failing tests**
+
+```bash
+git add __tests__/eslint/no-unused-viewmodel-properties.test.ts
+git commit -m "test: add failing tests for no-unused-viewmodel-properties rule"
+```
+
+---
+
+## Chunk 4: Rule Implementation
+
+### Task 8: Implement viewModel property extraction
+
+**Files:**
+- Modify: `lib/eslint/rules/no-unused-viewmodel-properties.ts`
+
+The goal of this task is to make the rule detect `presenterFactory` calls and extract viewModel property names from the AST. No file scanning yet — just the AST traversal.
+
+- [ ] **Step 1: Replace the rule skeleton with full implementation**
+
+Replace `lib/eslint/rules/no-unused-viewmodel-properties.ts` entirely:
+
+```typescript
+import type { Rule } from 'eslint'
+import type { Node, CallExpression, Property, ObjectExpression, ArrowFunctionExpression, FunctionExpression, ReturnStatement } from 'estree'
+import fs from 'node:fs'
+import path from 'node:path'
+
+interface ViewModelProperty {
+  name: string
+  node: Node
+}
+
+function extractViewModelProperties(callNode: CallExpression): ViewModelProperty[] {
+  const callback = callNode.arguments[0]
+  if (
+    !callback ||
+    (callback.type !== 'ArrowFunctionExpression' && callback.type !== 'FunctionExpression')
+  ) return []
+
+  const body = (callback as ArrowFunctionExpression | FunctionExpression).body
+  if (body.type !== 'BlockStatement') return []
+
+  const returnStatement = body.body.find((s): s is ReturnStatement => s.type === 'ReturnStatement')
+  if (!returnStatement?.argument || returnStatement.argument.type !== 'ObjectExpression') return []
+
+  const returnObj = returnStatement.argument as ObjectExpression
+  const viewModelProp = returnObj.properties.find(
+    (p): p is Property =>
+      p.type === 'Property' &&
+      ((p.key.type === 'Identifier' && p.key.name === 'viewModel') ||
+        (p.key.type === 'Literal' && p.key.value === 'viewModel'))
+  )
+  if (!viewModelProp) return []
+
+  const computedCall = viewModelProp.value
+  if (computedCall.type !== 'CallExpression') return []
+
+  const computedCallback = computedCall.arguments[0]
+  if (
+    !computedCallback ||
+    (computedCallback.type !== 'ArrowFunctionExpression' &&
+      computedCallback.type !== 'FunctionExpression')
+  ) return []
+
+  let viewModelObj: ObjectExpression | undefined
+  const cbBody = (computedCallback as ArrowFunctionExpression | FunctionExpression).body
+  if (cbBody.type === 'ObjectExpression') {
+    viewModelObj = cbBody as ObjectExpression
+  } else if (cbBody.type === 'BlockStatement') {
+    const ret = cbBody.body.find((s): s is ReturnStatement => s.type === 'ReturnStatement')
+    if (ret?.argument?.type === 'ObjectExpression') {
+      viewModelObj = ret.argument as ObjectExpression
+    }
+  }
+  if (!viewModelObj) return []
+
+  return viewModelObj.properties
+    .filter((p): p is Property => p.type === 'Property')
+    .map((p) => ({
+      name: p.key.type === 'Identifier' ? p.key.name : String((p.key as any).value),
+      node: p.key,
+    }))
+}
+
+function findProjectRoot(filePath: string): string {
+  let dir = path.dirname(filePath)
+  while (dir !== path.parse(dir).root) {
+    if (fs.existsSync(path.join(dir, 'package.json'))) return dir
+    dir = path.dirname(dir)
+  }
+  return path.dirname(filePath)
+}
+
+function findVueFiles(root: string): string[] {
+  const results: string[] = []
+
+  function scan(dir: string): void {
+    let entries
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true })
+    } catch {
+      return
+    }
+    for (const entry of entries) {
+      if (entry.name.startsWith('.') || entry.name === 'node_modules' || entry.name === 'dist') {
+        continue
+      }
+      const full = path.join(dir, entry.name)
+      if (entry.isDirectory()) scan(full)
+      else if (entry.name.endsWith('.vue')) results.push(full)
+    }
+  }
+
+  scan(root)
+  return results
+}
+
+function importsPresenter(vueFilePath: string, presenterFilePath: string): boolean {
+  let content: string
+  try {
+    content = fs.readFileSync(vueFilePath, 'utf8')
+  } catch {
+    return false
+  }
+
+  const presenterWithoutExt = presenterFilePath.replace(/\.(ts|tsx|js|jsx)$/, '')
+  const importRegex = /from\s+['"]([^'"]+)['"]/g
+  let match: RegExpExecArray | null
+
+  while ((match = importRegex.exec(content)) !== null) {
+    const importPath = match[1]
+    if (!importPath.startsWith('.')) continue
+    const vueDir = path.dirname(vueFilePath)
+    const resolved = path.resolve(vueDir, importPath).replace(/\.(ts|tsx|js|jsx)$/, '')
+    if (resolved === presenterWithoutExt) return true
+  }
+
+  return false
+}
+
+function getViewModelLocalName(scriptContent: string): string | null {
+  // Matches: const { viewModel } = ... or const { viewModel: alias } = ...
+  // \b prevents matching e.g. "storeViewModel" as "viewModel"
+  const match = scriptContent.match(/\{\s*viewModel\b(?:\s*:\s*(\w+))?\s*[,}]/)
+  if (!match) return null
+  return match[1] ?? 'viewModel'
+}
+
+function isPropertyUsedInVueFile(vueFilePath: string, propertyName: string): boolean {
+  let content: string
+  try {
+    content = fs.readFileSync(vueFilePath, 'utf8')
+  } catch {
+    return false
+  }
+
+  const scriptSetupMatch = content.match(/<script\b[^>]*\bsetup\b[^>]*>([\s\S]*?)<\/script>/)
+  const scriptContent = scriptSetupMatch?.[1] ?? ''
+  const localName = getViewModelLocalName(scriptContent)
+  // File doesn't destructure viewModel at all — treat as neutral (skip), not as "unused"
+  if (!localName) return true
+
+  const templateMatch = content.match(/<template[^>]*>([\s\S]*?)<\/template>/)
+  const templateContent = templateMatch?.[1] ?? ''
+
+  // Negative lookbehind on left + negative lookahead on right = full word boundary
+  const regex = new RegExp(
+    `(?<![\\w$])${escapeRegex(localName)}\\.${escapeRegex(propertyName)}(?![\\w$])`
+  )
+
+  return regex.test(templateContent) || regex.test(scriptContent)
+}
+
+function escapeRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+const rule: Rule.RuleModule = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description: 'Disallow unused viewModel properties in presenter files',
+    },
+    messages: {
+      unusedProperty: 'viewModel property "{{property}}" is not used in any importing .vue file',
+    },
+    schema: [],
+  },
+  create(context) {
+    return {
+      CallExpression(node) {
+        if (node.callee.type !== 'Identifier' || node.callee.name !== 'presenterFactory') return
+
+        const properties = extractViewModelProperties(node)
+        if (properties.length === 0) return
+
+        const presenterFilePath =
+          typeof (context as any).filename === 'string'
+            ? (context as any).filename
+            : context.getFilename()
+
+        const projectRoot = findProjectRoot(presenterFilePath)
+        const vueFiles = findVueFiles(projectRoot)
+        const importingVueFiles = vueFiles.filter((f) => importsPresenter(f, presenterFilePath))
+
+        if (importingVueFiles.length === 0) return
+
+        for (const { name, node: keyNode } of properties) {
+          // every: property must be used in ALL importing .vue files (each file is independent)
+          const isUsed = importingVueFiles.every((f) => isPropertyUsedInVueFile(f, name))
+          if (!isUsed) {
+            context.report({
+              node: keyNode,
+              messageId: 'unusedProperty',
+              data: { property: name },
+            })
+          }
+        }
+      },
+    }
+  },
+}
+
+export default rule
+```
+
+- [ ] **Step 2: Run tests**
+
+```bash
+npm test -- __tests__/eslint/no-unused-viewmodel-properties.test.ts
+```
+
+Expected: All 4 tests pass.
+
+- [ ] **Step 3: Run the full test suite to confirm no regressions**
+
+```bash
+npm test
+```
+
+Expected: All existing tests still pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add lib/eslint/rules/no-unused-viewmodel-properties.ts
+git commit -m "feat: implement no-unused-viewmodel-properties eslint rule"
+```
+
+---
+
+## Chunk 5: Build Integration
+
+### Task 9: Update Vite config for multi-entry build
+
+**Files:**
+- Modify: `vite.config.ts`
+
+- [ ] **Step 1: Read current vite.config.ts**
+
+Verify current content before editing (already read above, but confirm nothing changed).
+
+- [ ] **Step 2: Update the `lib` build configuration**
+
+In `vite.config.ts`, replace the `lib` block:
+
+Old:
+```typescript
+lib: {
+  entry: resolve(__dirname, 'lib/main.ts'),
+  fileName: 'main',
+  formats: ['es'],
+},
+```
+
+New:
+```typescript
+lib: {
+  entry: {
+    main: resolve(__dirname, 'lib/main.ts'),
+    eslint: resolve(__dirname, 'lib/eslint/index.ts'),
+  },
+  formats: ['es'],
+  fileName: (format, entryName) => `${entryName}.js`,
+},
+```
+
+- [ ] **Step 3: Verify TypeScript compiles cleanly with new files**
+
+```bash
+npx vue-tsc --noEmit
+```
+
+Expected: No errors. (`@types/node` is already in devDependencies so `fs`/`path` resolve fine.)
+
+- [ ] **Step 4: Mark `eslint` as external in rollupOptions**
+
+In the `rollupOptions.external` array, add `'eslint'`:
+
+Old:
+```typescript
+external: ["vue"],
+```
+
+New:
+```typescript
+external: ["vue", "eslint"],
+```
+
+---
+
+### Task 10: Update package.json exports and build
+
+**Files:**
+- Modify: `package.json`
+
+- [ ] **Step 1: Add `exports` map and update `types`**
+
+In `package.json`, add an `"exports"` field and update `"types"`:
+
+```json
+"exports": {
+  ".": {
+    "import": "./dist/main.js",
+    "types": "./dist/types/main.d.ts"
+  },
+  "./eslint": {
+    "import": "./dist/eslint.js",
+    "types": "./dist/types/eslint/index.d.ts"
+  }
+},
+```
+
+Keep the existing `"main"` and `"types"` fields for backwards compatibility.
+
+- [ ] **Step 2: Run the build**
+
+```bash
+npm run build
+```
+
+Expected: `dist/main.js` and `dist/eslint.js` both emitted. No errors.
+
+- [ ] **Step 3: Verify dist output**
+
+```bash
+ls dist/
+```
+
+Expected output includes: `main.js`, `eslint.js`, `types/` directory.
+
+- [ ] **Step 4: Run tests one final time**
+
+```bash
+npm test
+```
+
+Expected: All tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add vite.config.ts package.json
+git commit -m "feat: expose eslint plugin from library build"
+```
+
+---
+
+## Consumer Usage
+
+Once shipped, consumers configure the plugin in their `eslint.config.js`:
+
+```js
+import modelVuePresenter from 'model-vue-presenter/eslint'
+
+export default [
+  {
+    plugins: { 'model-vue-presenter': modelVuePresenter },
+    rules: {
+      'model-vue-presenter/no-unused-viewmodel-properties': 'error',
+    },
+  },
+]
+```

--- a/docs/superpowers/specs/2026-03-10-eslint-plugin-design.md
+++ b/docs/superpowers/specs/2026-03-10-eslint-plugin-design.md
@@ -1,0 +1,120 @@
+# ESLint Plugin: no-unused-viewmodel-properties
+
+**Date:** 2026-03-10
+**Status:** Approved
+
+## Problem
+
+Users of `model-vue-presenter` sometimes leave unused properties in the `viewModel` computed object — either forgotten dead code, or properties exposed solely for testing purposes (anti-pattern, since `.spy()` already handles testing needs). There is no automated way to catch this today.
+
+## Solution
+
+A custom ESLint plugin shipped as part of this library. Consumers opt in by adding the plugin to their ESLint config. The library also uses the plugin on its own test fixtures to verify it works.
+
+## Architecture
+
+The plugin is exported from this library under a dedicated entry point:
+
+```js
+import modelVuePresenter from 'model-vue-presenter/eslint'
+
+export default [
+  {
+    plugins: { 'model-vue-presenter': modelVuePresenter },
+    rules: { 'model-vue-presenter/no-unused-viewmodel-properties': 'error' }
+  }
+]
+```
+
+The plugin exposes one rule: **`no-unused-viewmodel-properties`**.
+
+## Rule: `no-unused-viewmodel-properties`
+
+### Trigger
+
+The rule runs on `.ts`/`.js` files. It activates when it finds a `presenterFactory(...)` `CallExpression` — no filename convention required.
+
+### Step 1 — Property Extraction (AST)
+
+Traverses the `presenterFactory` callback's return statement to find the `viewModel` key, unwraps the `computed(() => ({ ... }))` call, and collects the property names from the inner object literal.
+
+AST path:
+```
+CallExpression(presenterFactory)
+  └─ ArrowFunctionExpression (callback)
+       └─ ReturnStatement
+            └─ ObjectExpression
+                 └─ Property[key=viewModel]
+                      └─ CallExpression(computed)
+                           └─ ArrowFunctionExpression
+                                └─ ObjectExpression  ← extract keys here
+```
+
+### Step 2 — Finding Importer `.vue` Files
+
+From the presenter file's directory, walks upward to find the nearest `package.json` (project root). Globs all `.vue` files under the project root. Reads each and checks whether it contains an import path that resolves to this presenter file.
+
+### Step 3 — Local Alias Detection
+
+For each matching `.vue` file, scans the `<script setup>` section for the destructuring call and extracts the **local variable name** used for `viewModel`:
+
+```ts
+const { viewModel } = usePresenter()          // localName = "viewModel"
+const { viewModel: storeViewModel } = ...     // localName = "storeViewModel"
+```
+
+If no destructuring of `viewModel` is found, the `.vue` file is skipped — it is not consuming the viewModel, so properties used there do not count as "used."
+
+### Step 4 — Usage Detection
+
+For each matching `.vue` file (with a resolved local name), extracts the raw text of both `<template>` and `<script setup>` sections. For each viewModel property, checks for the pattern `localName.propertyName` using a word-boundary-aware regex.
+
+A property is considered **used** if it appears in at least one importing `.vue` file.
+
+### Step 5 — Reporting
+
+Any property not found in any importing `.vue` file is reported at its key node in the presenter file:
+
+```
+viewModel property "showSkeletonLoader" is not used in any importing .vue file
+```
+
+Errors are reported in the **presenter file**, at the exact property key node.
+
+### Scope
+
+- Supports standard `viewModel.property` access pattern
+- Supports `viewModel` aliased at destructuring call site
+- Each `.vue` file is analyzed independently — a property must be used in each file that imports the presenter
+- Destructured viewModel properties (e.g. `const { headline } = viewModel`) are out of scope for now (extensible later)
+
+## Testing Strategy
+
+Uses Vitest + ESLint's `RuleTester`. Fixture files on disk replace mocking — the rule reads real `.vue` files, which keeps tests realistic and fixtures serve as documentation.
+
+### Structure
+
+```
+__tests__/
+  eslint/
+    fixtures/
+      used-all-properties/
+        use-pet-store.presenter.ts   ← presenter with N viewModel props
+        pet-store.vue                ← template using all N props
+      unused-property/
+        use-pet-store.presenter.ts   ← presenter with N viewModel props
+        pet-store.vue                ← template using N-1 props
+      used-in-script-setup/
+        use-counter.presenter.ts
+        counter.vue                  ← property accessed in <script setup> only
+      viewmodel-alias/
+        use-counter.presenter.ts
+        counter.vue                  ← destructures viewModel as custom name
+    no-unused-viewmodel-properties.test.ts
+```
+
+Valid cases assert zero errors. Invalid cases assert the exact property name reported and the node location.
+
+## Packaging
+
+A new build entry point is added to `vite.config.ts` for `lib/eslint.ts`. This file exports the plugin object with the rule. The `package.json` exports map is updated with an `eslint` condition so consumers can import `model-vue-presenter/eslint`.

--- a/docs/superpowers/specs/2026-03-10-eslint-plugin-design.md
+++ b/docs/superpowers/specs/2026-03-10-eslint-plugin-design.md
@@ -69,7 +69,7 @@ If no destructuring of `viewModel` is found, the `.vue` file is skipped — it i
 
 For each matching `.vue` file (with a resolved local name), extracts the raw text of both `<template>` and `<script setup>` sections. For each viewModel property, checks for the pattern `localName.propertyName` using a word-boundary-aware regex.
 
-A property is considered **used** if it appears in at least one importing `.vue` file.
+A property is considered **used** only if it appears in **every** importing `.vue` file (each file is analyzed independently).
 
 ### Step 5 — Reporting
 

--- a/lib/eslint/index.ts
+++ b/lib/eslint/index.ts
@@ -1,0 +1,9 @@
+import noUnusedViewModelProperties from './rules/no-unused-viewmodel-properties'
+
+const plugin = {
+  rules: {
+    'no-unused-viewmodel-properties': noUnusedViewModelProperties,
+  },
+}
+
+export default plugin

--- a/lib/eslint/rules/no-unused-viewmodel-properties.ts
+++ b/lib/eslint/rules/no-unused-viewmodel-properties.ts
@@ -1,0 +1,19 @@
+import type { Rule } from 'eslint'
+
+const rule: Rule.RuleModule = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description: 'Disallow unused viewModel properties in presenter files',
+    },
+    messages: {
+      unusedProperty: 'viewModel property "{{property}}" is not used in any importing .vue file',
+    },
+    schema: [],
+  },
+  create(context) {
+    return {}
+  },
+}
+
+export default rule

--- a/lib/eslint/rules/no-unused-viewmodel-properties.ts
+++ b/lib/eslint/rules/no-unused-viewmodel-properties.ts
@@ -142,8 +142,9 @@ function isPropertyUsedInVueFile(vueFilePath: string, propertyName: string): boo
   const templateContent = templateMatch?.[1] ?? ''
 
   // Negative lookbehind on left + negative lookahead on right = full word boundary
+  // Matches both `localName.property` (template auto-unwrap) and `localName.value.property` (script access)
   const regex = new RegExp(
-    `(?<![\\w$])${escapeRegex(localName)}\\.${escapeRegex(propertyName)}(?![\\w$])`
+    `(?<![\\w$])${escapeRegex(localName)}(?:\\.value)?\\.${escapeRegex(propertyName)}(?![\\w$])`
   )
 
   return regex.test(templateContent) || regex.test(scriptContent)
@@ -169,13 +170,13 @@ const rule: Rule.RuleModule = {
       CallExpression(node) {
         if (node.callee.type !== 'Identifier' || node.callee.name !== 'presenterFactory') return
 
-        const properties = extractViewModelProperties(node)
+        const properties = extractViewModelProperties(node as unknown as CallExpression)
         if (properties.length === 0) return
 
         const presenterFilePath =
           typeof (context as any).filename === 'string'
             ? (context as any).filename
-            : context.getFilename()
+            : (context as any).getFilename()
 
         const projectRoot = findProjectRoot(presenterFilePath)
         const vueFiles = findVueFiles(projectRoot)

--- a/lib/eslint/rules/no-unused-viewmodel-properties.ts
+++ b/lib/eslint/rules/no-unused-viewmodel-properties.ts
@@ -1,4 +1,157 @@
 import type { Rule } from 'eslint'
+import type { Node, CallExpression, Property, ObjectExpression, ArrowFunctionExpression, FunctionExpression, ReturnStatement } from 'estree'
+import fs from 'node:fs'
+import path from 'node:path'
+
+interface ViewModelProperty {
+  name: string
+  node: Node
+}
+
+function extractViewModelProperties(callNode: CallExpression): ViewModelProperty[] {
+  const callback = callNode.arguments[0]
+  if (
+    !callback ||
+    (callback.type !== 'ArrowFunctionExpression' && callback.type !== 'FunctionExpression')
+  ) return []
+
+  const body = (callback as ArrowFunctionExpression | FunctionExpression).body
+  if (body.type !== 'BlockStatement') return []
+
+  const returnStatement = body.body.find((s): s is ReturnStatement => s.type === 'ReturnStatement')
+  if (!returnStatement?.argument || returnStatement.argument.type !== 'ObjectExpression') return []
+
+  const returnObj = returnStatement.argument as ObjectExpression
+  const viewModelProp = returnObj.properties.find(
+    (p): p is Property =>
+      p.type === 'Property' &&
+      ((p.key.type === 'Identifier' && p.key.name === 'viewModel') ||
+        (p.key.type === 'Literal' && p.key.value === 'viewModel'))
+  )
+  if (!viewModelProp) return []
+
+  const computedCall = viewModelProp.value
+  if (computedCall.type !== 'CallExpression') return []
+
+  const computedCallback = computedCall.arguments[0]
+  if (
+    !computedCallback ||
+    (computedCallback.type !== 'ArrowFunctionExpression' &&
+      computedCallback.type !== 'FunctionExpression')
+  ) return []
+
+  let viewModelObj: ObjectExpression | undefined
+  const cbBody = (computedCallback as ArrowFunctionExpression | FunctionExpression).body
+  if (cbBody.type === 'ObjectExpression') {
+    viewModelObj = cbBody as ObjectExpression
+  } else if (cbBody.type === 'BlockStatement') {
+    const ret = cbBody.body.find((s): s is ReturnStatement => s.type === 'ReturnStatement')
+    if (ret?.argument?.type === 'ObjectExpression') {
+      viewModelObj = ret.argument as ObjectExpression
+    }
+  }
+  if (!viewModelObj) return []
+
+  return viewModelObj.properties
+    .filter((p): p is Property => p.type === 'Property')
+    .map((p) => ({
+      name: p.key.type === 'Identifier' ? p.key.name : String((p.key as any).value),
+      node: p.key,
+    }))
+}
+
+function findProjectRoot(filePath: string): string {
+  let dir = path.dirname(filePath)
+  while (dir !== path.parse(dir).root) {
+    if (fs.existsSync(path.join(dir, 'package.json'))) return dir
+    dir = path.dirname(dir)
+  }
+  return path.dirname(filePath)
+}
+
+function findVueFiles(root: string): string[] {
+  const results: string[] = []
+
+  function scan(dir: string): void {
+    let entries
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true })
+    } catch {
+      return
+    }
+    for (const entry of entries) {
+      if (entry.name.startsWith('.') || entry.name === 'node_modules' || entry.name === 'dist') {
+        continue
+      }
+      const full = path.join(dir, entry.name)
+      if (entry.isDirectory()) scan(full)
+      else if (entry.name.endsWith('.vue')) results.push(full)
+    }
+  }
+
+  scan(root)
+  return results
+}
+
+function importsPresenter(vueFilePath: string, presenterFilePath: string): boolean {
+  let content: string
+  try {
+    content = fs.readFileSync(vueFilePath, 'utf8')
+  } catch {
+    return false
+  }
+
+  const presenterWithoutExt = presenterFilePath.replace(/\.(ts|tsx|js|jsx)$/, '')
+  const importRegex = /from\s+['"]([^'"]+)['"]/g
+  let match: RegExpExecArray | null
+
+  while ((match = importRegex.exec(content)) !== null) {
+    const importPath = match[1]
+    if (!importPath.startsWith('.')) continue
+    const vueDir = path.dirname(vueFilePath)
+    const resolved = path.resolve(vueDir, importPath).replace(/\.(ts|tsx|js|jsx)$/, '')
+    if (resolved === presenterWithoutExt) return true
+  }
+
+  return false
+}
+
+function getViewModelLocalName(scriptContent: string): string | null {
+  // Matches: const { viewModel } = ... or const { viewModel: alias } = ...
+  // \b prevents matching e.g. "storeViewModel" as "viewModel"
+  const match = scriptContent.match(/\{\s*viewModel\b(?:\s*:\s*(\w+))?\s*[,}]/)
+  if (!match) return null
+  return match[1] ?? 'viewModel'
+}
+
+function isPropertyUsedInVueFile(vueFilePath: string, propertyName: string): boolean {
+  let content: string
+  try {
+    content = fs.readFileSync(vueFilePath, 'utf8')
+  } catch {
+    return false
+  }
+
+  const scriptSetupMatch = content.match(/<script\b[^>]*\bsetup\b[^>]*>([\s\S]*?)<\/script>/)
+  const scriptContent = scriptSetupMatch?.[1] ?? ''
+  const localName = getViewModelLocalName(scriptContent)
+  // File doesn't destructure viewModel at all — treat as neutral (skip), not as "unused"
+  if (!localName) return true
+
+  const templateMatch = content.match(/<template[^>]*>([\s\S]*?)<\/template>/)
+  const templateContent = templateMatch?.[1] ?? ''
+
+  // Negative lookbehind on left + negative lookahead on right = full word boundary
+  const regex = new RegExp(
+    `(?<![\\w$])${escapeRegex(localName)}\\.${escapeRegex(propertyName)}(?![\\w$])`
+  )
+
+  return regex.test(templateContent) || regex.test(scriptContent)
+}
+
+function escapeRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
 
 const rule: Rule.RuleModule = {
   meta: {
@@ -12,7 +165,37 @@ const rule: Rule.RuleModule = {
     schema: [],
   },
   create(context) {
-    return {}
+    return {
+      CallExpression(node) {
+        if (node.callee.type !== 'Identifier' || node.callee.name !== 'presenterFactory') return
+
+        const properties = extractViewModelProperties(node)
+        if (properties.length === 0) return
+
+        const presenterFilePath =
+          typeof (context as any).filename === 'string'
+            ? (context as any).filename
+            : context.getFilename()
+
+        const projectRoot = findProjectRoot(presenterFilePath)
+        const vueFiles = findVueFiles(projectRoot)
+        const importingVueFiles = vueFiles.filter((f) => importsPresenter(f, presenterFilePath))
+
+        if (importingVueFiles.length === 0) return
+
+        for (const { name, node: keyNode } of properties) {
+          // every: property must be used in ALL importing .vue files (each file is independent)
+          const isUsed = importingVueFiles.every((f) => isPropertyUsedInVueFile(f, name))
+          if (!isUsed) {
+            context.report({
+              node: keyNode,
+              messageId: 'unusedProperty',
+              data: { property: name },
+            })
+          }
+        }
+      },
+    }
   },
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,22 @@
 {
   "name": "model-vue-presenter",
-  "version": "1.2.0",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "model-vue-presenter",
-      "version": "1.2.0",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
         "@trivago/prettier-plugin-sort-imports": "^5.2.2"
       },
       "devDependencies": {
         "@types/node": "^20.10.8",
+        "@typescript-eslint/parser": "^8.57.0",
         "@vitejs/plugin-vue": "^4.5.2",
         "@vue/test-utils": "^2.4.3",
+        "eslint": "^10.0.3",
         "jsdom": "^23.2.0",
         "typescript": "^5.5.3",
         "vite": "^5.0.8",
@@ -772,6 +774,204 @@
         "node": ">=12"
       }
     },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.23.3",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.3.tgz",
+      "integrity": "sha512-j+eEWmB6YYLwcNOdlwQ6L2OsptI/LO6lNBuLIqe5R7RetD658HLoF+Mn7LzYmAWWNNzdC6cqP+L6r8ujeYXWLw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^3.0.3",
+        "debug": "^4.3.1",
+        "minimatch": "^10.2.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/brace-expansion": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
+      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/minimatch": {
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.3.tgz",
+      "integrity": "sha512-lzGN0onllOZCGroKJmRwY6QcEHxbjBw1gwB8SgRSqK8YbbtEXMvKynsXc3553ckIEBxsbMBU7oOZXKIPGZNeZw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.1.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.1.1.tgz",
+      "integrity": "sha512-QUPblTtE51/7/Zhfv8BDwO0qkkzQL7P/aWWbqcf4xWLEYn1oKjdO0gglQBB4GAsu7u6wjijbCmzsUTy6mnk6oQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.3.tgz",
+      "integrity": "sha512-iM869Pugn9Nsxbh/YHRqYiqd23AmIbxJOcpUMOuWCVNdoQJ5ZtwL6h3t0bcZzJUlC3Dq9jCFCESBZnX0GTv7iQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.6.1.tgz",
+      "integrity": "sha512-iH1B076HoAshH1mLpHMgwdGeTs0CYwL0SPMkGuSebZrwBp16v415e9NZXg2jtrqPVQjf6IANe2Vtlr5KswtcZQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.1.1",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
+      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
+      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.1",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -1362,6 +1562,13 @@
       "integrity": "sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==",
       "dev": true
     },
+    "node_modules/@types/esrecurse": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
@@ -1376,6 +1583,13 @@
       "dependencies": {
         "@types/unist": "*"
       }
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/linkify-it": {
       "version": "5.0.0",
@@ -1419,6 +1633,187 @@
       "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.20.tgz",
       "integrity": "sha512-g9gZnnXVq7gM7v3tJCWV/qw7w+KeOlSHAhgF9RytFyifW6AF61hdT2ucrYhPq9hLs5JIryeupHV3qGk95dH9ow==",
       "dev": true
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.57.0.tgz",
+      "integrity": "sha512-XZzOmihLIr8AD1b9hL9ccNMzEMWt/dE2u7NyTY9jJG6YNiNthaD5XtUHVF2uCXZ15ng+z2hT3MVuxnUYhq6k1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.57.0",
+        "@typescript-eslint/types": "8.57.0",
+        "@typescript-eslint/typescript-estree": "8.57.0",
+        "@typescript-eslint/visitor-keys": "8.57.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.57.0.tgz",
+      "integrity": "sha512-pR+dK0BlxCLxtWfaKQWtYr7MhKmzqZxuii+ZjuFlZlIGRZm22HnXFqa2eY+90MUz8/i80YJmzFGDUsi8dMOV5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.57.0",
+        "@typescript-eslint/types": "^8.57.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.57.0.tgz",
+      "integrity": "sha512-nvExQqAHF01lUM66MskSaZulpPL5pgy5hI5RfrxviLgzZVffB5yYzw27uK/ft8QnKXI2X0LBrHJFr1TaZtAibw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.57.0",
+        "@typescript-eslint/visitor-keys": "8.57.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.57.0.tgz",
+      "integrity": "sha512-LtXRihc5ytjJIQEH+xqjB0+YgsV4/tW35XKX3GTZHpWtcC8SPkT/d4tqdf1cKtesryHm2bgp6l555NYcT2NLvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.57.0.tgz",
+      "integrity": "sha512-dTLI8PEXhjUC7B9Kre+u0XznO696BhXcTlOn0/6kf1fHaQW8+VjJAVHJ3eTI14ZapTxdkOmc80HblPQLaEeJdg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.57.0.tgz",
+      "integrity": "sha512-m7faHcyVg0BT3VdYTlX8GdJEM7COexXxS6KqGopxdtkQRvBanK377QDHr4W/vIPAR+ah9+B/RclSW5ldVniO1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.57.0",
+        "@typescript-eslint/tsconfig-utils": "8.57.0",
+        "@typescript-eslint/types": "8.57.0",
+        "@typescript-eslint/visitor-keys": "8.57.0",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
+      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.57.0.tgz",
+      "integrity": "sha512-zm6xx8UT/Xy2oSr2ZXD0pZo7Jx2XsCoID2IUh9YSTFRu7z+WdwYTRk6LhUftm1crwqbuoF6I8zAFeCMw0YjwDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.57.0",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
     },
     "node_modules/@vitejs/plugin-vue": {
       "version": "4.6.2",
@@ -1928,15 +2323,26 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.12.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
-      "integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/acorn-walk": {
@@ -2205,10 +2611,11 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -2269,11 +2676,12 @@
       "dev": true
     },
     "node_modules/debug": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz",
-      "integrity": "sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -2301,6 +2709,13 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
@@ -2400,11 +2815,246 @@
         "@esbuild/win32-x64": "0.21.5"
       }
     },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.0.3.tgz",
+      "integrity": "sha512-COV33RzXZkqhG9P2rZCFl9ZmJ7WL+gQSCRzE7RhkbclbQPtLAWReL7ysA0Sh4c8Im2U9ynybdR56PV0XcKvqaQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@eslint/config-array": "^0.23.3",
+        "@eslint/config-helpers": "^0.5.2",
+        "@eslint/core": "^1.1.1",
+        "@eslint/plugin-kit": "^0.6.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^9.1.2",
+        "eslint-visitor-keys": "^5.0.1",
+        "espree": "^11.1.1",
+        "esquery": "^1.7.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "minimatch": "^10.2.4",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@types/esrecurse": "^4.3.1",
+        "@types/estree": "^1.0.8",
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-scope/node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eslint/node_modules/ajv": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/eslint/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/eslint/node_modules/brace-expansion": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
+      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/eslint/node_modules/minimatch": {
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/espree": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^5.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
       "devOptional": true
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/execa": {
       "version": "8.0.1",
@@ -2440,6 +3090,64 @@
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.1.tgz",
+      "integrity": "sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/focus-trap": {
       "version": "7.5.4",
@@ -2567,6 +3275,19 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/glob/node_modules/minimatch": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
@@ -2683,6 +3404,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/import-lazy": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-4.0.0.tgz",
@@ -2690,6 +3421,16 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
       }
     },
     "node_modules/ini": {
@@ -2713,6 +3454,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -2720,6 +3471,19 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-potential-custom-element-name": {
@@ -2873,11 +3637,25 @@
         "node": ">=6"
       }
     },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/jsonfile": {
       "version": "4.0.0",
@@ -2888,11 +3666,35 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
     "node_modules/kolorist": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/kolorist/-/kolorist-1.8.0.tgz",
       "integrity": "sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==",
       "dev": true
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
     },
     "node_modules/local-pkg": {
       "version": "0.5.0",
@@ -2908,6 +3710,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/lodash": {
@@ -3051,9 +3869,10 @@
       }
     },
     "node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/muggle-string": {
       "version": "0.3.1",
@@ -3078,6 +3897,13 @@
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/nopt": {
       "version": "7.2.1",
@@ -3136,6 +3962,24 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/p-limit": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-5.0.0.tgz",
@@ -3146,6 +3990,51 @@
       },
       "engines": {
         "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate/node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -3174,6 +4063,16 @@
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
       "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
       "dev": true
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/path-key": {
       "version": "3.1.1",
@@ -3292,6 +4191,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/prettier": {
@@ -3462,10 +4371,11 @@
       "peer": true
     },
     "node_modules/semver": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "dev": true,
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -3765,6 +4675,54 @@
       "integrity": "sha512-1/eK7zUnIklz4JUUlL+658n58XO2hHLQfSk1Zf2LKieUjxidN16eKFEoDEfjHc3ohofSSqK3X5yO6VGb6iW8Lw==",
       "dev": true
     },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/tinypool": {
       "version": "0.8.4",
       "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.8.4.tgz",
@@ -3808,6 +4766,32 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz",
+      "integrity": "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/type-detect": {
@@ -4339,6 +5323,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -33,12 +33,20 @@
     "docs:preview": "vitepress preview docs"
   },
   "peerDependencies": {
-    "vue": ">=3.0.0 <4.0.0"
+    "vue": ">=3.0.0 <4.0.0",
+    "eslint": ">=8.0.0"
+  },
+  "peerDependenciesMeta": {
+    "eslint": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@types/node": "^20.10.8",
+    "@typescript-eslint/parser": "^8.57.0",
     "@vitejs/plugin-vue": "^4.5.2",
     "@vue/test-utils": "^2.4.3",
+    "eslint": "^10.0.3",
     "jsdom": "^23.2.0",
     "typescript": "^5.5.3",
     "vite": "^5.0.8",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,16 @@
   "main": "./dist/main.js",
   "types": "dist/types/main.d.ts",
   "type": "module",
+  "exports": {
+    ".": {
+      "import": "./dist/main.js",
+      "types": "./dist/types/main.d.ts"
+    },
+    "./eslint": {
+      "import": "./dist/eslint.js",
+      "types": "./dist/types/eslint/index.d.ts"
+    }
+  },
   "scripts": {
     "build": "vue-tsc && vite build",
     "test": "vitest",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,7 +25,7 @@
     "module": "ESNext",
     "lib": ["ES6", "DOM", "DOM.Iterable"],
     "skipLibCheck": true,
-    "types": ["vite/client"],
+    "types": ["vite/client", "node"],
 
     /* Bundler mode */
     "moduleResolution": "bundler",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,13 +16,16 @@ export default defineConfig({
     sourcemap: true,
 
     lib: {
-      entry: resolve(__dirname, 'lib/main.ts'),
-      fileName: 'main',
+      entry: {
+        main: resolve(__dirname, 'lib/main.ts'),
+        eslint: resolve(__dirname, 'lib/eslint/index.ts'),
+      },
       formats: ['es'],
+      fileName: (_format, entryName) => `${entryName}.js`,
     },
 
     rollupOptions: {
-      external: ["vue"],
+      external: ["vue", "eslint"],
       output: {
         globals: {
           vue: 'Vue'

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -25,7 +25,7 @@ export default defineConfig({
     },
 
     rollupOptions: {
-      external: ["vue", "eslint"],
+      external: ["vue", "eslint", "node:fs", "node:path", "fs", "path"],
       output: {
         globals: {
           vue: 'Vue'


### PR DESCRIPTION
## Summary

- Adds a new `no-unused-viewmodel-properties` ESLint rule that reports viewModel properties in presenter files not accessed in any importing `.vue` file
- Rule is exposed as a plugin from `model-vue-presenter/eslint` — consumers opt in via their ESLint config
- Handles viewModel aliasing (`const { viewModel: myVM } = ...`), script setup usage, and `ComputedRef` `.value` unwrap patterns

## Test Plan

- [x] 25 tests pass (`npm test`)
- [x] `dist/eslint.js` builds correctly with `node:fs`/`node:path` as external imports
- [ ] Verify consumer usage: `import plugin from 'model-vue-presenter/eslint'` resolves correctly after build

<img width="1624" height="1056" alt="image" src="https://github.com/user-attachments/assets/3cb22c13-2d9a-4c9b-abf5-991253230d13" />
